### PR TITLE
Update the runtime version from 49 to 50, and more

### DIFF
--- a/io.github.jorchube.monitorets.json
+++ b/io.github.jorchube.monitorets.json
@@ -1,10 +1,10 @@
 {
-    "app-id" : "io.github.jorchube.monitorets",
-    "runtime" : "org.gnome.Platform",
-    "runtime-version" : "49",
-    "sdk" : "org.gnome.Sdk",
-    "command" : "monitorets",
-    "finish-args" : [
+    "app-id": "io.github.jorchube.monitorets",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "50",
+    "sdk": "org.gnome.Sdk",
+    "command": "monitorets",
+    "finish-args": [
         "--share=ipc",
         "--socket=fallback-x11",
         "--device=dri",
@@ -12,27 +12,15 @@
         "--filesystem=host:ro",
         "--share=network"
     ],
-    "cleanup" : [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
-    ],
-    "modules" : [
+    "modules": [
         "pypi-dependencies.json",
         {
-            "name" : "monitorets",
-            "builddir" : true,
-            "buildsystem" : "meson",
-            "sources" : [
+            "name": "monitorets",
+            "buildsystem": "meson",
+            "sources": [
                 {
-                    "type" : "git",
-                    "url" : "https://github.com/jorchube/monitorets.git",
+                    "type": "git",
+                    "url": "https://github.com/jorchube/monitorets.git",
                     "tag": "0.10.1",
                     "commit": "503ff6694f75d8435257590bd7a1fd48188197c3"
                 }

--- a/pypi-dependencies.json
+++ b/pypi-dependencies.json
@@ -1,5 +1,5 @@
 {
-    "name": "python3-modules",
+    "name": "pypi-dependencies",
     "buildsystem": "simple",
     "build-commands": [],
     "modules": [
@@ -12,8 +12,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/e1/88/bdd0a41e5857d5d703287598cbf08dad90aed56774ea52ae071bae9071b6/psutil-7.1.3.tar.gz",
-                    "sha256": "6c86281738d77335af7aec228328e944b30930899ea760ecf33a4dba66be5e74"
+                    "url": "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz",
+                    "sha256": "0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372"
                 }
             ]
         },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# Use the following command to regenerate Python modules
+# flatpak-pip-generator --runtime=org.gnome.Sdk//50 -r requirements.txt -o pypi-dependencies
+
+psutil
+xdg


### PR DESCRIPTION
- Update the runtime version to 50
- Drop ineffective cleanup commands
- Create a requirements.txt file
- Regenerate Python modules
- Comply with Flathub styling guidelines

See: https://docs.flathub.org/docs/for-app-authors/requirements#flatpak-builder-manifest-style-guide